### PR TITLE
Initial commit of xorshift* PRNG

### DIFF
--- a/lib/generators/xorshift.rb
+++ b/lib/generators/xorshift.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+# This implements a 64-bit Xorshift* PRNG
+# Code adapted from https://en.wikipedia.org/wiki/Xorshift#xorshift.2A
+# License for the above at https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License
+
+require_relative '../generator.rb'
+
+class XorshiftStar < Generator
+
+  def initialize(*args)
+    super(*args)
+    # Seed with 1 as 0 produces all zeroes
+    @i = 1
+  end
+
+  def self.summary
+    "64-bit xorshift* PRNG"
+  end
+
+  def self.description
+    desc = <<-DESC_END
+    This generates a non-cryptographically secure pseudo-random sequence by a 64-bit xorshift* generator (xorshift 
+    times a modulus). This generator will produce a peroidicity of 2^64 - 1.
+    DESC_END
+    desc.gsub(/\s+/, " ").strip
+  end
+
+  def xorshift_star(sseed)
+    x = sseed.unpack('Q>')[0]
+    x ^= x >> 12
+    x ^= x << 25
+    x ^= x >> 27
+    return x * 2685821657736338717
+  end
+    
+  def next_chunk
+    @i = xorshift_star([@i].pack('Q>'))
+    [@i].pack('Q>')
+  end
+
+end
+XorshiftStar.run if __FILE__ == $0


### PR DESCRIPTION
Implemented (I think - I've never used Ruby before and the bit-wise operations I -think- work as intended) a 64-bit xorshift* PRNG. As far as I know, this should produce good psuedo-random numbers as long as it's seeded with a non-zero number. Not cryptographically secure. Algorithm adapted from https://en.wikipedia.org/wiki/Xorshift#xorshift.2A, which should fall under the license at https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License which is linked in the generator.